### PR TITLE
Fixed presenter installer link at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 Use the golang present tool 
 ```
 # setup GOPATH before running this: https://golang.org/doc/code.html#GOPATH
-go get github.com/golang/tools/cmd/present
+# Install presenter: https://github.com/audreylim/go-presenter#install
 cd /path/to/this/slide
 $GOPATH/bin/present
 ```
 
 ## Live
+Following links are deprecated-- try using above tool and compile it yourself!
 
 My tehlug presentation :  http://go-talks.appspot.com/github.com/fzerorubigd/golang-slides/tehlug.slide
 


### PR DESCRIPTION
presenter package is not going to be installed by the previous command. Relevant link added for installation.
